### PR TITLE
Features/reset lastsubmissions route

### DIFF
--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -227,6 +227,22 @@ const userController = {
         }
     },
 
+    resetLastSubmissions: async (req: Request, res: Response) => {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            res.status(statusCodes.MISSING_PARAMS).json(
+                errors.formatWith(errorMessage).array()[0]
+            );
+        } else {
+            try {
+                await userDBInteractions.resetLastSubmissions();
+                res.status(statusCodes.SUCCESS).json();
+            } catch (error) {
+                res.status(statusCodes.SERVER_ERROR).json(error);
+            }
+        }
+    },
+
     delete: async (req: Request, res: Response) => {
         const errors = validationResult(req);
         if (!errors.isEmpty()) {

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -228,18 +228,11 @@ const userController = {
     },
 
     resetLastSubmissions: async (req: Request, res: Response) => {
-        const errors = validationResult(req);
-        if (!errors.isEmpty()) {
-            res.status(statusCodes.MISSING_PARAMS).json(
-                errors.formatWith(errorMessage).array()[0]
-            );
-        } else {
-            try {
-                await userDBInteractions.resetLastSubmissions();
-                res.status(statusCodes.SUCCESS).json();
-            } catch (error) {
-                res.status(statusCodes.SERVER_ERROR).json(error);
-            }
+        try {
+            await userDBInteractions.resetLastSubmissions();
+            res.status(statusCodes.SUCCESS).json();
+        } catch (error) {
+            res.status(statusCodes.SERVER_ERROR).json(error);
         }
     },
 

--- a/src/database/interactions/user.ts
+++ b/src/database/interactions/user.ts
@@ -31,5 +31,14 @@ export const userDBInteractions = {
 
     delete: (userId: string): Promise<IUserModel> => {
         return User.findByIdAndDelete(userId).exec();
+    },
+
+    resetLastSubmissions: (): Promise<IUserModel[]> => {
+        return User.updateMany(
+            {},
+            {
+                $set: { "platformData.codeforces.lastSubmission": {} }
+            }
+        ).exec();
     }
 };

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -6,6 +6,8 @@ const userRouter: Router = Router();
 
 userRouter.get("/", userValidator("GET /users"), userController.index);
 
+userRouter.get("/resetLastSubmissions", userController.resetLastSubmissions);
+
 userRouter.get(
     "/:userId",
     userValidator("GET /users/:userId"),

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -6,8 +6,6 @@ const userRouter: Router = Router();
 
 userRouter.get("/", userValidator("GET /users"), userController.index);
 
-userRouter.get("/resetLastSubmissions", userController.resetLastSubmissions);
-
 userRouter.get(
     "/:userId",
     userValidator("GET /users/:userId"),
@@ -21,6 +19,8 @@ userRouter.put(
     userValidator("PUT /users/:userId"),
     userController.update
 );
+
+userRouter.patch("/resetLastSubmissions", userController.resetLastSubmissions);
 
 userRouter.patch(
     "/:userId/problems",

--- a/tests/unit/controllers/user.test.ts
+++ b/tests/unit/controllers/user.test.ts
@@ -109,6 +109,21 @@ describe("Users controller tests", () => {
         });
     });
 
+    describe("ResetLastSubmission", () => {
+        it("status 200: resets last submissions", async () => {
+            await userController.resetLastSubmissions(mockReq, mockRes);
+            sinon.assert.calledOnce(stubs.userDB.resetLastSubmissions);
+            sinon.assert.calledWith(mockRes.status, statusCodes.SUCCESS);
+            sinon.assert.calledOnce(mockRes.json);
+        });
+
+        it("status 500: fails to reset last submissions", async () => {
+            stubs.userDB.resetLastSubmissions.throws();
+            await userController.resetLastSubmissions(mockReq, mockRes);
+            sinon.assert.calledWith(mockRes.status, statusCodes.SERVER_ERROR);
+        });
+    });
+
     describe("Show", () => {
         let req;
         beforeEach(() => {

--- a/tests/unit/stubs/user.ts
+++ b/tests/unit/stubs/user.ts
@@ -12,6 +12,10 @@ export const userDBInteractionsStubs = () => {
         findByUsername: sinon.stub(userDBInteractions, "findByUsername"),
         update: sinon.stub(userDBInteractions, "update"),
         delete: sinon.stub(userDBInteractions, "delete"),
+        resetLastSubmissions: sinon.stub(
+            userDBInteractions,
+            "resetLastSubmissions"
+        ),
 
         restore() {
             this.create.restore();
@@ -21,6 +25,7 @@ export const userDBInteractionsStubs = () => {
             this.findByUsername.restore();
             this.update.restore();
             this.delete.restore();
+            this.resetLastSubmissions.restore();
         }
     };
 };


### PR DESCRIPTION
resolves #27 

a route that resets the last submissions field for all users (to be used when a new problemset is added)